### PR TITLE
Pick up include-dirs option from cabal file.

### DIFF
--- a/Distribution/Dev/Interactive.hs
+++ b/Distribution/Dev/Interactive.hs
@@ -79,6 +79,7 @@ ghcOpts path bi mlbi deps = filter validGHCiFlag $ concat $
   hcOptions buildCompilerFlavor,
   addf "-X" display . allExtensions,
   addf "-i" (dir </>) . (autogendir:) . hsSourceDirs,
+  addf "-I" (dir </>) . (autogendir:) . includeDirs,
   add "-optP" . cppOptions,
   add "-optc" . ccOptions,
   add "-optl" . ldOptions,


### PR DESCRIPTION
This patch translates any include-dirs: blah directive into -Iblah when invoking GHCi. It also adds the autogen directory to the include path as that's where cabal_macros.h lives.
